### PR TITLE
Set up H2-backed test profiles for quiz and question services

### DIFF
--- a/question-service/pom.xml
+++ b/question-service/pom.xml
@@ -48,16 +48,21 @@
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
 		</dependency> -->
 
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <optional>true</optional>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/question-service/src/test/resources/application-test.properties
+++ b/question-service/src/test/resources/application-test.properties
@@ -1,0 +1,16 @@
+spring.application.name=question-service
+
+spring.datasource.url=jdbc:h2:mem:questiondb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.defer-datasource-initialization=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+
+spring.test.database.replace=none
+
+eureka.client.enabled=false
+spring.cloud.discovery.enabled=false

--- a/question-service/src/test/resources/application.properties
+++ b/question-service/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.profiles.active=test

--- a/quiz-service/pom.xml
+++ b/quiz-service/pom.xml
@@ -48,16 +48,21 @@
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <optional>true</optional>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/quiz-service/src/test/resources/application-test.properties
+++ b/quiz-service/src/test/resources/application-test.properties
@@ -1,0 +1,16 @@
+spring.application.name=quiz-service
+
+spring.datasource.url=jdbc:h2:mem:quizdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.defer-datasource-initialization=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+
+spring.test.database.replace=none
+
+eureka.client.enabled=false
+spring.cloud.discovery.enabled=false

--- a/quiz-service/src/test/resources/application.properties
+++ b/quiz-service/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.profiles.active=test


### PR DESCRIPTION
## Summary
- add H2 as a test-scoped dependency in the question-service and quiz-service modules
- configure dedicated `application-test.properties` files that swap the PostgreSQL datasource for in-memory H2 during tests
- automatically activate the new `test` profile when the test scope is used