### PR TITLE
Add unit tests for question and quiz service layers

### DIFF
--- a/question-service/pom.xml
+++ b/question-service/pom.xml
@@ -48,16 +48,21 @@
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
 		</dependency> -->
 
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <optional>true</optional>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/question-service/src/test/java/com/rga/question_service/controller/QuestionControllerTest.java
+++ b/question-service/src/test/java/com/rga/question_service/controller/QuestionControllerTest.java
@@ -1,0 +1,168 @@
+package com.rga.question_service.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rga.question_service.model.Question;
+import com.rga.question_service.model.QuestionWrapper;
+import com.rga.question_service.model.Response;
+import com.rga.question_service.service.QuestionService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(QuestionController.class)
+class QuestionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private QuestionService questionService;
+
+    @Test
+    void getAllQuestionsReturnsListFromService() throws Exception {
+        List<Question> questions = List.of(createQuestion(1));
+        when(questionService.getAllQuestions()).thenReturn(new ResponseEntity<>(questions, HttpStatus.OK));
+
+        mockMvc.perform(get("/question/allQuestions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].questionTitle").value("Question 1"));
+
+        verify(questionService).getAllQuestions();
+    }
+
+    @Test
+    void getQuestionsByCategoryPassesPathVariableToService() throws Exception {
+        List<Question> questions = List.of(createQuestion(2));
+        when(questionService.getQuestionsByCategory("java")).thenReturn(new ResponseEntity<>(questions, HttpStatus.OK));
+
+        mockMvc.perform(get("/question/category/{category}", "java"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(2));
+
+        verify(questionService).getQuestionsByCategory("java");
+    }
+
+    @Test
+    void addQuestionPassesBodyToService() throws Exception {
+        Question question = createQuestion(3);
+        when(questionService.addQuestion(any(Question.class))).thenReturn(new ResponseEntity<>("success", HttpStatus.CREATED));
+
+        mockMvc.perform(post("/question/add")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(question)))
+                .andExpect(status().isCreated())
+                .andExpect(content().string("success"));
+
+        ArgumentCaptor<Question> captor = ArgumentCaptor.forClass(Question.class);
+        verify(questionService).addQuestion(captor.capture());
+        Question captured = captor.getValue();
+        assertThat(captured.getQuestionTitle()).isEqualTo("Question 3");
+        assertThat(captured.getCategory()).isEqualTo("general");
+    }
+
+    @Test
+    void getQuestionsForQuizSendsQueryParamsToService() throws Exception {
+        List<Integer> ids = List.of(4, 5);
+        when(questionService.getQuestionsForQuiz("spring", 2)).thenReturn(new ResponseEntity<>(ids, HttpStatus.OK));
+
+        mockMvc.perform(get("/question/generate")
+                        .param("categoryName", "spring")
+                        .param("numQuestions", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0]").value(4));
+
+        verify(questionService).getQuestionsForQuiz("spring", 2);
+    }
+
+    @Test
+    void getQuestionsFromIdSendsBodyToService() throws Exception {
+        List<Integer> ids = List.of(6, 7);
+        List<QuestionWrapper> wrappers = List.of(createWrapper(6));
+        when(questionService.getQuestionsFromId(anyList())).thenReturn(new ResponseEntity<>(wrappers, HttpStatus.OK));
+
+        mockMvc.perform(post("/question/getQuestions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(ids)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id").value(6));
+
+        ArgumentCaptor<List<Integer>> captor = ArgumentCaptor.forClass(List.class);
+        verify(questionService).getQuestionsFromId(captor.capture());
+        assertThat(captor.getValue()).containsExactlyElementsOf(ids);
+    }
+
+    @Test
+    void getScoreSendsResponsesToService() throws Exception {
+        List<Response> responses = List.of(createResponse(8, "A"));
+        when(questionService.getScore(anyList())).thenReturn(new ResponseEntity<>(1, HttpStatus.OK));
+
+        mockMvc.perform(post("/question/getScore")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(responses)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("1"));
+
+        ArgumentCaptor<List<Response>> captor = ArgumentCaptor.forClass(List.class);
+        verify(questionService).getScore(captor.capture());
+        assertThat(captor.getValue()).hasSize(1);
+    }
+
+    private Question createQuestion(int id) {
+        Question question = new Question();
+        question.setId(id);
+        question.setQuestionTitle("Question " + id);
+        question.setOption1("A");
+        question.setOption2("B");
+        question.setOption3("C");
+        question.setOption4("D");
+        question.setRightAnswer("A");
+        question.setCategory("general");
+        question.setDifficultylevel("easy");
+        return question;
+    }
+
+    private QuestionWrapper createWrapper(int id) {
+        QuestionWrapper wrapper = new QuestionWrapper();
+        wrapper.setId(id);
+        wrapper.setQuestionTitle("Question " + id);
+        wrapper.setOption1("A");
+        wrapper.setOption2("B");
+        wrapper.setOption3("C");
+        wrapper.setOption4("D");
+        return wrapper;
+    }
+
+    private Response createResponse(int id, String answer) {
+        Response response = new Response();
+        response.setId(id);
+        response.setResponse(answer);
+        return response;
+    }
+}

--- a/question-service/src/test/java/com/rga/question_service/service/QuestionServiceTest.java
+++ b/question-service/src/test/java/com/rga/question_service/service/QuestionServiceTest.java
@@ -1,0 +1,153 @@
+package com.rga.question_service.service;
+
+import com.rga.question_service.dao.QuestionDao;
+import com.rga.question_service.model.Question;
+import com.rga.question_service.model.QuestionWrapper;
+import com.rga.question_service.model.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QuestionServiceTest {
+
+    @Mock
+    private QuestionDao questionDao;
+
+    @InjectMocks
+    private QuestionService questionService;
+
+    @Test
+    void getAllQuestionsReturnsOkWhenDaoSucceeds() {
+        List<Question> questions = List.of(createQuestion(1));
+        when(questionDao.findAll()).thenReturn(questions);
+
+        ResponseEntity<List<Question>> response = questionService.getAllQuestions();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertThat(response.getBody()).containsExactlyElementsOf(questions);
+    }
+
+    @Test
+    void getAllQuestionsReturnsBadRequestWhenDaoThrows() {
+        when(questionDao.findAll()).thenThrow(new RuntimeException("database down"));
+
+        ResponseEntity<List<Question>> response = questionService.getAllQuestions();
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertThat(response.getBody()).isEmpty();
+    }
+
+    @Test
+    void getQuestionsByCategoryReturnsOkWhenDaoSucceeds() {
+        List<Question> questions = List.of(createQuestion(5));
+        when(questionDao.findByCategory("java")).thenReturn(questions);
+
+        ResponseEntity<List<Question>> response = questionService.getQuestionsByCategory("java");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertThat(response.getBody()).containsExactlyElementsOf(questions);
+    }
+
+    @Test
+    void getQuestionsByCategoryReturnsBadRequestWhenDaoThrows() {
+        when(questionDao.findByCategory("java")).thenThrow(new RuntimeException("no category"));
+
+        ResponseEntity<List<Question>> response = questionService.getQuestionsByCategory("java");
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertThat(response.getBody()).isEmpty();
+    }
+
+    @Test
+    void addQuestionPersistsEntityAndReturnsSuccess() {
+        Question question = createQuestion(10);
+
+        ResponseEntity<String> response = questionService.addQuestion(question);
+
+        ArgumentCaptor<Question> captor = ArgumentCaptor.forClass(Question.class);
+        verify(questionDao).save(captor.capture());
+        assertThat(captor.getValue()).isEqualTo(question);
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals("success", response.getBody());
+    }
+
+    @Test
+    void getQuestionsForQuizReturnsIdsFromDao() {
+        List<Integer> ids = List.of(1, 2, 3);
+        when(questionDao.findRandomQuestionsByCategory("spring", 3)).thenReturn(ids);
+
+        ResponseEntity<List<Integer>> response = questionService.getQuestionsForQuiz("spring", 3);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertThat(response.getBody()).containsExactlyElementsOf(ids);
+    }
+
+    @Test
+    void getQuestionsFromIdReturnsWrappersForEachQuestion() {
+        Question question = createQuestion(7);
+        when(questionDao.findById(7)).thenReturn(Optional.of(question));
+
+        ResponseEntity<List<QuestionWrapper>> response = questionService.getQuestionsFromId(List.of(7));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertThat(response.getBody()).hasSize(1);
+        QuestionWrapper wrapper = response.getBody().get(0);
+        assertEquals(question.getId(), wrapper.getId());
+        assertEquals(question.getQuestionTitle(), wrapper.getQuestionTitle());
+        assertEquals(question.getOption1(), wrapper.getOption1());
+        assertEquals(question.getOption2(), wrapper.getOption2());
+        assertEquals(question.getOption3(), wrapper.getOption3());
+        assertEquals(question.getOption4(), wrapper.getOption4());
+    }
+
+    @Test
+    void getScoreCountsOnlyCorrectAnswers() {
+        Question questionOne = createQuestion(1);
+        questionOne.setRightAnswer("A");
+        Question questionTwo = createQuestion(2);
+        questionTwo.setRightAnswer("B");
+
+        Response responseOne = new Response();
+        responseOne.setId(1);
+        responseOne.setResponse("A");
+        Response responseTwo = new Response();
+        responseTwo.setId(2);
+        responseTwo.setResponse("C");
+
+        when(questionDao.findById(1)).thenReturn(Optional.of(questionOne));
+        when(questionDao.findById(2)).thenReturn(Optional.of(questionTwo));
+
+        ResponseEntity<Integer> response = questionService.getScore(List.of(responseOne, responseTwo));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody());
+    }
+
+    private Question createQuestion(int id) {
+        Question question = new Question();
+        question.setId(id);
+        question.setQuestionTitle("Question " + id);
+        question.setOption1("A");
+        question.setOption2("B");
+        question.setOption3("C");
+        question.setOption4("D");
+        question.setRightAnswer("A");
+        question.setCategory("general");
+        question.setDifficultylevel("easy");
+        return question;
+    }
+}

--- a/question-service/src/test/resources/application-test.properties
+++ b/question-service/src/test/resources/application-test.properties
@@ -1,0 +1,16 @@
+spring.application.name=question-service
+
+spring.datasource.url=jdbc:h2:mem:questiondb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.defer-datasource-initialization=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+
+spring.test.database.replace=none
+
+eureka.client.enabled=false
+spring.cloud.discovery.enabled=false

--- a/question-service/src/test/resources/application.properties
+++ b/question-service/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.profiles.active=test

--- a/quiz-service/pom.xml
+++ b/quiz-service/pom.xml
@@ -48,16 +48,21 @@
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <optional>true</optional>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/quiz-service/src/test/java/com/rga/quiz_service/controller/QuizControllerTest.java
+++ b/quiz-service/src/test/java/com/rga/quiz_service/controller/QuizControllerTest.java
@@ -1,0 +1,99 @@
+package com.rga.quiz_service.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rga.quiz_service.model.QuestionWrapper;
+import com.rga.quiz_service.model.QuizDto;
+import com.rga.quiz_service.model.Response;
+import com.rga.quiz_service.service.QuizService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(QuizController.class)
+class QuizControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private QuizService quizService;
+
+    @Test
+    void createQuizForwardsDtoToService() throws Exception {
+        QuizDto dto = new QuizDto();
+        dto.setCategoryName("java");
+        dto.setNumQuestions(2);
+        dto.setTitle("Java Quiz");
+        when(quizService.createQuiz(anyString(), anyInt(), anyString()))
+                .thenReturn(new ResponseEntity<>("Success", HttpStatus.CREATED));
+
+        mockMvc.perform(post("/quiz/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(content().string("Success"));
+
+        verify(quizService).createQuiz("java", 2, "Java Quiz");
+    }
+
+    @Test
+    void getQuizQuestionsReturnsBodyFromService() throws Exception {
+        List<QuestionWrapper> wrappers = List.of(new QuestionWrapper(1, "Question 1", "A", "B", "C", "D"));
+        when(quizService.getQuizQuestions(5)).thenReturn(new ResponseEntity<>(wrappers, HttpStatus.OK));
+
+        mockMvc.perform(get("/quiz/get/{id}", 5))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id").value(1));
+
+        verify(quizService).getQuizQuestions(5);
+    }
+
+    @Test
+    void submitQuizPassesResponsesToService() throws Exception {
+        List<Response> responses = List.of(createResponse(1, "A"));
+        when(quizService.calculateResult(anyInt(), anyList()))
+                .thenReturn(new ResponseEntity<>(2, HttpStatus.OK));
+
+        mockMvc.perform(post("/quiz/submit/{id}", 9)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(responses)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("2"));
+
+        ArgumentCaptor<List<Response>> captor = ArgumentCaptor.forClass(List.class);
+        verify(quizService).calculateResult(9, captor.capture());
+        assertThat(captor.getValue()).hasSize(1);
+    }
+
+    private Response createResponse(int id, String answer) {
+        Response response = new Response();
+        response.setId(id);
+        response.setResponse(answer);
+        return response;
+    }
+}

--- a/quiz-service/src/test/java/com/rga/quiz_service/service/QuizServiceTest.java
+++ b/quiz-service/src/test/java/com/rga/quiz_service/service/QuizServiceTest.java
@@ -1,0 +1,98 @@
+package com.rga.quiz_service.service;
+
+import com.rga.quiz_service.dao.QuizDao;
+import com.rga.quiz_service.feign.QuizInterface;
+import com.rga.quiz_service.model.QuestionWrapper;
+import com.rga.quiz_service.model.Quiz;
+import com.rga.quiz_service.model.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QuizServiceTest {
+
+    @Mock
+    private QuizDao quizDao;
+
+    @Mock
+    private QuizInterface quizInterface;
+
+    @InjectMocks
+    private QuizService quizService;
+
+    @Test
+    void createQuizStoresIdsReturnedByQuestionService() {
+        List<Integer> ids = List.of(1, 2, 3);
+        when(quizInterface.getQuestionsForQuiz("java", 3))
+                .thenReturn(new ResponseEntity<>(ids, HttpStatus.OK));
+
+        ResponseEntity<String> response = quizService.createQuiz("java", 3, "Java Quiz");
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals("Success", response.getBody());
+
+        ArgumentCaptor<Quiz> captor = ArgumentCaptor.forClass(Quiz.class);
+        verify(quizDao).save(captor.capture());
+        Quiz saved = captor.getValue();
+        assertEquals("Java Quiz", saved.getTitle());
+        assertThat(saved.getQuestionsIds()).containsExactlyElementsOf(ids);
+    }
+
+    @Test
+    void getQuizQuestionsReturnsWrappersFromFeignClient() {
+        Quiz quiz = new Quiz();
+        quiz.setId(5);
+        quiz.setTitle("Spring");
+        List<Integer> ids = List.of(10, 11);
+        quiz.setQuestionsIds(ids);
+        when(quizDao.findById(5)).thenReturn(Optional.of(quiz));
+
+        List<QuestionWrapper> wrappers = List.of(createWrapper(10));
+        ResponseEntity<List<QuestionWrapper>> wrapperResponse = new ResponseEntity<>(wrappers, HttpStatus.OK);
+        when(quizInterface.getQuestionsFromId(ids)).thenReturn(wrapperResponse);
+
+        ResponseEntity<List<QuestionWrapper>> response = quizService.getQuizQuestions(5);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertThat(response.getBody()).containsExactlyElementsOf(wrappers);
+        verify(quizInterface).getQuestionsFromId(ids);
+    }
+
+    @Test
+    void calculateResultDelegatesToFeignClient() {
+        List<Response> responses = List.of(createResponse(1, "A"));
+        ResponseEntity<Integer> scoreResponse = new ResponseEntity<>(1, HttpStatus.OK);
+        when(quizInterface.getScore(responses)).thenReturn(scoreResponse);
+
+        ResponseEntity<Integer> response = quizService.calculateResult(9, responses);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody());
+        verify(quizInterface).getScore(responses);
+    }
+
+    private QuestionWrapper createWrapper(int id) {
+        return new QuestionWrapper(id, "Question " + id, "A", "B", "C", "D");
+    }
+
+    private Response createResponse(int id, String answer) {
+        Response response = new Response();
+        response.setId(id);
+        response.setResponse(answer);
+        return response;
+    }
+}

--- a/quiz-service/src/test/resources/application-test.properties
+++ b/quiz-service/src/test/resources/application-test.properties
@@ -1,0 +1,16 @@
+spring.application.name=quiz-service
+
+spring.datasource.url=jdbc:h2:mem:quizdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.defer-datasource-initialization=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+
+spring.test.database.replace=none
+
+eureka.client.enabled=false
+spring.cloud.discovery.enabled=false

--- a/quiz-service/src/test/resources/application.properties
+++ b/quiz-service/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.profiles.active=test


### PR DESCRIPTION
## Summary
- add Mockito-based unit tests that exercise the QuestionService CRUD and scoring logic
- cover QuestionController endpoints with MockMvc to verify routing and payload handling
- create analogous service and controller unit tests for the quiz-service module
